### PR TITLE
fix-latest-tagging-for-builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/base
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
@@ -112,7 +112,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
@@ -123,7 +123,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/worker
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
@@ -134,7 +134,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/solr
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base
+            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
@@ -112,7 +112,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}
+            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
@@ -123,7 +123,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker
+            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
@@ -134,7 +134,7 @@ jobs:
         uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr
+            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,39 +98,47 @@ jobs:
       - name: Retag action for base
         if: ${{ inputs.baseTarget != '' }}
         id: meta-base
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/base
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
       - name: Retag action for web
         if: ${{ inputs.webTarget != '' }}
         id: meta-web
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
       - name: Retag action for worker
         if: ${{ inputs.workerTarget != '' }}
         id: meta-worker
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/worker
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
       - name: Retag action for solr
         if: ${{ inputs.solrTarget != '' }}
         id: meta-solr
-        uses: docker/metadata-action@v4.1.1
+        uses: docker/metadata-action@v5.7.0
         with:
           images: |
-            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/solr
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
       - name: Build and push base
         if: ${{ inputs.baseTarget != '' }}
         uses: notch8/actions/build-and-push@v0.0.25


### PR DESCRIPTION
- Update the retagging action to: docker/metadata-action@v5.7.0

# Story
When building images upon merging to main the retag action in the build step is not working. The latest tag is not getting applied to the latest for main. This helps cut build times down when caching the latest images in the docker compose file.