### PR TITLE
make push job arch-aware for single- and multi-arch builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -167,18 +167,28 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create multiarch manifests
         run: |
-          components_list=$(echo '${{ inputs.components }}' | jq -r '.[]' | tr '\n' ' ')
-          for component in $components_list; do
-            docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/$component:${{ env.TAG }} \
-              ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/$component:${{ env.TAG }}-amd64 \
-              ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/$component:${{ env.TAG }}-arm64
+          platforms=()
+          for os in $(echo '${{ inputs.os }}' | jq -r '.[]'); do
+            if [ "$os" = "ubuntu-latest" ]; then platforms+=("amd64"); else platforms+=("arm64"); fi
+          done
+          for component in $(echo '${{ inputs.components }}' | jq -r '.[]'); do
+            srcs=()
+            for p in "${platforms[@]}"; do
+              srcs+=("${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/${component}:${{ env.TAG }}-${p}")
+            done
+            docker buildx imagetools create -t "${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/${component}:${{ env.TAG }}" "${srcs[@]}"
           done
       - name: Create multiarch latest manifests (default branch only)
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
-          components_list=$(echo '${{ inputs.components }}' | jq -r '.[]' | tr '\n' ' ')
-          for component in $components_list; do
-            docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/$component:latest \
-              ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/$component:latest-amd64 \
-              ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/$component:latest-arm64
+          platforms=()
+          for os in $(echo '${{ inputs.os }}' | jq -r '.[]'); do
+            if [ "$os" = "ubuntu-latest" ]; then platforms+=("amd64"); else platforms+=("arm64"); fi
+          done
+          for component in $(echo '${{ inputs.components }}' | jq -r '.[]'); do
+            srcs=()
+            for p in "${platforms[@]}"; do
+              srcs+=("${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/${component}:latest-${p}")
+            done
+            docker buildx imagetools create -t "${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/${component}:latest" "${srcs[@]}"
           done


### PR DESCRIPTION
# Make push job architecture-aware for single- and multi-arch builds

## Problem

Ansur uses an older `phusion/passenger-ruby` base image that is only published for `amd64`; there is no `arm64` variant available.

After upgrading to `notch8/actions` v1.0.9, the reusable `build.yaml` workflow always runs a separate push job that assembles a multi-architecture manifest. That job assumes both `:<tag>-amd64` and `:<tag>-arm64` images exist and attempts to publish a combined manifest.

For repositories that intentionally build only `amd64` images, for example:

```yaml
os: '["ubuntu-latest"]'
```

the push job still expects an `arm64` image and tries to include it in the manifest. Because the `arm64` image was never built, the workflow fails during the manifest creation/push step.

Example failure:

- Ansur build run: https://github.com/notch8/ansur/actions/runs/27452349611
- Reproducing PR: https://github.com/notch8/ansur/pull/37 (`fix-push-arch-aware-manifests`)

## Solution

Make the push job architecture-aware by deriving the manifest from the architectures that were actually built.

- Single-architecture builds publish only the architecture-specific image(s) that exist.
- Multi-architecture builds continue to publish a combined manifest containing all built architectures.
- The reusable workflow no longer assumes both `amd64` and `arm64` artifacts are present.

This preserves existing multi-arch behavior while allowing repositories that can only build a single architecture to complete successfully.